### PR TITLE
Fix useCallback import

### DIFF
--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from "react"
+import React, { useState, useEffect, useRef } from "react"
 import Head from "next/head"
 import { useRouter } from "next/router"
 import { Button } from "@/components/ui/button"
@@ -65,7 +65,7 @@ export default function AppPage() {
   }, [user, loading, router])
 
   // Fetch user documents
-  const fetchDocuments = useCallback(async () => {
+  const fetchDocuments = React.useCallback(async () => {
     if (!user) return
     
     setIsLoadingDocuments(true)


### PR DESCRIPTION
## Summary
- adjust React import so `useCallback` is referenced via `React.useCallback`

## Testing
- `npm run lint`
- `npm run build` *(fails: ESLint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68826ce7b8e88325b2c500108191e6b1