### PR TITLE
Enforce supabase config

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,30 +1,22 @@
 import { createClient } from '@supabase/supabase-js'
-import { getConfig, isProduction } from './config'
+import { getConfig } from './config'
 
 const config = getConfig();
 
-// Validate Supabase configuration
+// Validate Supabase configuration strictly
 if (!config.supabase.url || !config.supabase.anonKey) {
-  const errors = [];
-  if (!config.supabase.url) errors.push('NEXT_PUBLIC_SUPABASE_URL');
-  if (!config.supabase.anonKey) errors.push('NEXT_PUBLIC_SUPABASE_ANON_KEY');
-  
-  // Only throw in production or if both are missing
-  if (isProduction() || errors.length === 2) {
-    throw new Error(`Missing required Supabase environment variables: ${errors.join(', ')}`);
-  }
-  
-  console.warn(`⚠️  Missing Supabase configuration: ${errors.join(', ')}`);
+  const missing: string[] = []
+  if (!config.supabase.url) missing.push('NEXT_PUBLIC_SUPABASE_URL')
+  if (!config.supabase.anonKey) missing.push('NEXT_PUBLIC_SUPABASE_ANON_KEY')
+  throw new Error(
+    `Missing Supabase environment variables: ${missing.join(', ')}`
+  )
 }
 
-// Create Supabase client with validated credentials
-export const supabase = createClient(
-  config.supabase.url || 'http://localhost:54321', // Fallback for development
-  config.supabase.anonKey || 'dummy-anon-key',     // Fallback for development
-  {
-    auth: {
-      persistSession: true,
-      detectSessionInUrl: true
-    }
-  }
-)
+// Create Supabase client using provided credentials
+export const supabase = createClient(config.supabase.url, config.supabase.anonKey, {
+  auth: {
+    persistSession: true,
+    detectSessionInUrl: true,
+  },
+})

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -40,6 +40,9 @@ export default function LoginPage() {
     } catch (err: unknown) {
       if (err instanceof Error) {
         setError(err.message)
+        if (err.message.includes('Missing Supabase environment variables')) {
+          alert(err.message)
+        }
       } else {
         setError("An unexpected error occurred.")
       }


### PR DESCRIPTION
## Summary
- remove fallback supabase credentials
- alert user when supabase vars are missing on login page

## Testing
- `npm run lint && npm run typecheck` *(fails: Missing script: typecheck)*

------
https://chatgpt.com/codex/tasks/task_e_68829257b18c8325a2b293d26fc6fb73