### PR TITLE
Improve upload API env guard and error handling

### DIFF
--- a/src/components/app/DocumentUpload.tsx
+++ b/src/components/app/DocumentUpload.tsx
@@ -65,7 +65,16 @@ export function DocumentUpload({ onUploadComplete, onDocumentListRefresh }: Docu
       clearInterval(progressInterval)
 
       if (!response.ok) {
-        throw new Error('Upload failed')
+        let errorMessage = 'Upload failed'
+        try {
+          const errorData = await response.json()
+          if (errorData?.error) {
+            errorMessage = errorData.error
+          }
+        } catch (e) {
+          // ignore json parse errors
+        }
+        throw new Error(errorMessage)
       }
 
       const data = await response.json()

--- a/src/pages/api/upload.ts
+++ b/src/pages/api/upload.ts
@@ -18,9 +18,14 @@ async function uploadHandler(req: AuthenticatedRequest, res: NextApiResponse) {
     return apiError(res, 405, 'Method not allowed', 'METHOD_NOT_ALLOWED')
   }
 
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    console.error('Upload API misconfiguration')
+    return apiError(res, 500, 'Server configuration error', 'CONFIG_ERROR')
+  }
+
   const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
   )
 
   const form = formidable({


### PR DESCRIPTION
## Summary
- check Supabase env vars before instantiating client in API upload handler
- surface error messages from the upload API in the DocumentUpload UI

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688292b84da0832583405bdd8b6c5e53