### PR TITLE
Fix closing tags in AppPage

### DIFF
--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -297,7 +297,6 @@ export default function AppPage() {
 
               </div>
             </div>
-          </div>
 
           {/* User Profile */}
           <div className="p-4 border-t border-gray-200 dark:border-gray-700">


### PR DESCRIPTION
## Summary
- remove stray closing `div` before User Profile section

## Testing
- `npx --yes tsc -p tsconfig.json --pretty false`
- `npx --yes eslint src/pages/app.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6883980fc2c483258b037b7ac5df545f