### PR TITLE
Fix UploadThing handler for Pages Router

### DIFF
--- a/src/pages/api/uploadthing.ts
+++ b/src/pages/api/uploadthing.ts
@@ -1,45 +1,22 @@
-import { createRouteHandler } from "uploadthing/next"
+import { createRouteHandler } from "uploadthing/next-legacy"
 import { ourFileRouter } from "@/lib/uploadthing"
-import type { NextApiRequest, NextApiResponse } from "next"
+import type { NextApiHandler } from "next"
 
-const { GET, POST } = createRouteHandler({
+/**
+ * Disable Next.js body parsing so UploadThing can handle the request stream.
+ * This allows uploads larger than Vercel's 4.5MB limit.
+ */
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+}
+
+const handler: NextApiHandler = createRouteHandler({
   router: ourFileRouter,
   config: {
     token: process.env.UPLOADTHING_TOKEN,
   },
 })
 
-// Convert App Router handlers to Pages Router format
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method === "GET") {
-    // Convert NextRequest to Request for UploadThing
-    const url = new URL(req.url!, `http://${req.headers.host}`)
-    const request = new Request(url, {
-      method: req.method,
-      headers: new Headers(req.headers as Record<string, string>),
-    })
-    
-    const response = await GET(request)
-    
-    // Convert Response back to NextApiResponse
-    const data = await response.text()
-    res.status(response.status).json(JSON.parse(data))
-  } else if (req.method === "POST") {
-    // Convert NextRequest to Request for UploadThing
-    const url = new URL(req.url!, `http://${req.headers.host}`)
-    const request = new Request(url, {
-      method: req.method,
-      headers: new Headers(req.headers as Record<string, string>),
-      body: JSON.stringify(req.body),
-    })
-    
-    const response = await POST(request)
-    
-    // Convert Response back to NextApiResponse
-    const data = await response.text()
-    res.status(response.status).json(JSON.parse(data))
-  } else {
-    res.setHeader("Allow", ["GET", "POST"])
-    res.status(405).end(`Method ${req.method} Not Allowed`)
-  }
-}
+export default handler


### PR DESCRIPTION
## Summary
- update API route to use `uploadthing/next-legacy`
- disable body parsing so larger uploads succeed
- send auth header through UploadThing hook instead of fetch override

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68854d0498c883259890ec39df9c5b4f