### PR TITLE
Fix UploadThing handler failing on GET/empty body

### DIFF
--- a/src/pages/api/uploadthing.ts
+++ b/src/pages/api/uploadthing.ts
@@ -21,9 +21,23 @@ const uploadThingHandler = createRouteHandler({
 })
 
 const handler: NextApiHandler = async (req, res) => {
+  // Only allow POST requests
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST')
+    return res.status(405).json({ error: 'Method Not Allowed' })
+  }
+
+  // Basic body presence check
+  const hasBody =
+    Boolean(req.headers['content-length']) ||
+    Boolean(req.headers['transfer-encoding'])
+  if (!hasBody) {
+    return res.status(400).json({ error: 'Missing or empty JSON body' })
+  }
+
   // Track whether we've sent a response
   let responseHandled = false
-  
+
   // Wrap response to debug what UploadThing is returning
   const debugRes = new DebugResponse(res)
   
@@ -58,19 +72,25 @@ const handler: NextApiHandler = async (req, res) => {
       stack: error instanceof Error ? error.stack : undefined,
       name: error instanceof Error ? error.name : undefined
     })
-    
-    // Try to send error response if possible
+
     if (!res.headersSent && !responseHandled) {
-      console.log("UploadThing API: Sending fallback error response")
-      res.status(500).json({ 
-        error: "UploadThing API failed",
+      // Provide a more specific message for JSON parse errors
+      const message =
+        error instanceof SyntaxError && /JSON/.test(error.message)
+          ? "Invalid JSON body"
+          : "UploadThing API failed"
+
+      res.status(message === "Invalid JSON body" ? 400 : 500).json({
+        error: message,
         message: String(error instanceof Error ? error.message : error),
         details: "Check server logs for more information",
-        timestamp: new Date().toISOString()
+        timestamp: new Date().toISOString(),
       })
       responseHandled = true
     } else {
-      console.error("UploadThing API: Response already sent, cannot send error response")
+      console.error(
+        "UploadThing API: Response already sent, cannot send error response"
+      )
     }
   } finally {
     // Final safety check - ensure SOMETHING was sent


### PR DESCRIPTION
## Summary
- enforce POST method for `/api/uploadthing`
- add early body presence check
- improve error handling for JSON parse failures

## Testing
- `npm test` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887f62872d883259ec040df4d26d502