### PR TITLE
Sanitize OM response logging

### DIFF
--- a/src/lib/validation/om-response.ts
+++ b/src/lib/validation/om-response.ts
@@ -121,10 +121,18 @@ export function validateAndFilterOmResponse(data: unknown): {
         `${err.path.join('.')}: ${err.message}`
       );
       
-      // Log validation failure for debugging
+      // Log validation failure with sanitized details to avoid exposing PII
+      const summary = typeof data === 'object' && data !== null
+        ? {
+            type: Array.isArray(data) ? 'array' : 'object',
+            keys: Object.keys(data).slice(0, 5)
+          }
+        : { type: typeof data };
+
       console.warn('OM Response validation failed:', {
         errors,
-        originalData: JSON.stringify(data, null, 2)
+        originalDataSummary: summary,
+        expectedShape: createEmptyOMResponse()
       });
       
       return {


### PR DESCRIPTION
## Summary
- avoid logging raw OM response data in `validateAndFilterOmResponse`
- include a sanitized summary and example shape when validation fails

## Testing
- `pnpm test` *(fails: Error retrieving document context, timeouts)*

------
https://chatgpt.com/codex/tasks/task_e_6889615f07788325ad9eea55d3af235d