### PR TITLE
Add financial range warnings to validation

### DIFF
--- a/src/lib/validation/__tests__/om-response.test.ts
+++ b/src/lib/validation/__tests__/om-response.test.ts
@@ -94,10 +94,11 @@ describe('OM Response Validation', () => {
       };
 
       const result = validateAndFilterOmResponse(validResponse);
-      
+
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
       expect(result.errors).toBeUndefined();
+      expect(result.warnings).toEqual([]);
       expect(result.data?.DealSnapshot.PropertyName).toBe("Sunset Plaza Apartments");
     });
 
@@ -161,11 +162,12 @@ describe('OM Response Validation', () => {
       };
 
       const result = validateAndFilterOmResponse(incompleteResponse);
-      
+
       expect(result.success).toBe(true);
       expect(result.data).toBeDefined();
       expect(result.data?.DealSnapshot.Address).toBe("");
       expect(result.data?.UnitMix).toEqual([]);
+      expect(result.warnings).toEqual([]);
     });
 
     it('should reject invalid structure', () => {
@@ -178,10 +180,11 @@ describe('OM Response Validation', () => {
       };
 
       const result = validateAndFilterOmResponse(invalidResponse);
-      
+
       expect(result.success).toBe(false);
       expect(result.errors).toBeDefined();
       expect(result.errors!.length).toBeGreaterThan(0);
+      expect(result.warnings).toBeUndefined();
     });
 
     it('should filter inappropriate recommended actions', () => {
@@ -250,12 +253,13 @@ describe('OM Response Validation', () => {
       };
 
       const result = validateAndFilterOmResponse(responseWithBadActions);
-      
+
       expect(result.success).toBe(true);
       expect(result.data?.RecommendedActions).toEqual([
         "Conduct market analysis",
         "Research comparables"
       ]);
+      expect(result.warnings).toEqual([]);
     });
 
     it('should validate cap rate ranges', () => {
@@ -318,9 +322,10 @@ describe('OM Response Validation', () => {
       };
 
       const result = validateAndFilterOmResponse(responseWithHighCapRate);
-      
+
       expect(result.success).toBe(false);
       expect(result.errors).toContainEqual(expect.stringContaining("Cap rate"));
+      expect(result.warnings).toBeUndefined();
     });
   });
 
@@ -330,7 +335,8 @@ describe('OM Response Validation', () => {
       
       const validation = validateAndFilterOmResponse(emptyResponse);
       expect(validation.success).toBe(true);
-      
+      expect(validation.warnings).toEqual([]);
+
       // Check all fields are empty strings
       expect(emptyResponse.DealSnapshot.PropertyName).toBe("");
       expect(emptyResponse.FinancialSummary.CapRate).toBe("");
@@ -450,33 +456,37 @@ describe('OM Response Validation', () => {
       };
 
       const result = validateAndFilterOmResponse(responseWithPII);
-      
+
       expect(result.success).toBe(true);
       expect(result.data?.LocationHighlights.Demographics).toContain("[REDACTED]");
       expect(result.data?.LocationHighlights.Demographics).not.toContain("john.doe@example.com");
+      expect(result.warnings).toEqual([]);
     });
   });
 
   describe('Error Handling', () => {
     it('should handle null input', () => {
       const result = validateAndFilterOmResponse(null);
-      
+
       expect(result.success).toBe(false);
       expect(result.errors).toBeDefined();
+      expect(result.warnings).toBeUndefined();
     });
 
     it('should handle undefined input', () => {
       const result = validateAndFilterOmResponse(undefined);
-      
+
       expect(result.success).toBe(false);
       expect(result.errors).toBeDefined();
+      expect(result.warnings).toBeUndefined();
     });
 
     it('should handle invalid JSON structure', () => {
       const result = validateAndFilterOmResponse("invalid json string");
-      
+
       expect(result.success).toBe(false);
       expect(result.errors).toBeDefined();
+      expect(result.warnings).toBeUndefined();
     });
   });
 });

--- a/src/lib/validation/om-response.ts
+++ b/src/lib/validation/om-response.ts
@@ -103,17 +103,21 @@ export type OMResponse = z.infer<typeof OMResponseSchema>;
  * Validates and filters OM response in a single pass
  * @param data - Raw response data to validate
  * @returns Validated and filtered OM response with fallbacks
+ *          and any financial range warnings
  */
 export function validateAndFilterOmResponse(data: unknown): {
   success: boolean;
   data?: OMResponse;
   errors?: string[];
+  warnings?: string[];
 } {
   try {
     const validated = OMResponseSchema.parse(data);
+    const warnings = validateFinancialRanges(validated);
     return {
       success: true,
-      data: validated
+      data: validated,
+      ...(warnings.length > 0 && { warnings })
     };
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -404,14 +404,16 @@ Please reference this document context in your response when relevant.`
       // Validate and filter structured response only if JSON was requested
       let validatedContent = assistantContent;
       let validationWarnings: string[] = [];
+      let warnings: string[] = [];
       
       if (useJsonSchema && assistantContent) {
         try {
           const parsedResponse = JSON.parse(assistantContent);
           const validation = validateAndFilterOmResponse(parsedResponse);
-          
+
           if (validation.success && validation.data) {
             validatedContent = JSON.stringify(validation.data);
+            warnings = validation.warnings || [];
           } else {
             console.warn('OM Response validation failed (non-streaming):', validation.errors);
             validationWarnings = validation.errors || [];
@@ -449,7 +451,8 @@ Please reference this document context in your response when relevant.`
         model: response.model,
         usage: response.usage,
         sessionId,
-        ...(validationWarnings.length > 0 && { validationWarnings })
+        ...(validationWarnings.length > 0 && { validationWarnings }),
+        ...(warnings.length > 0 && { warnings })
       })
     }
 


### PR DESCRIPTION
## Summary
- generate warnings from `validateFinancialRanges` after successful OM JSON validation
- surface `warnings` in chat API response alongside `validationWarnings`
- update tests for new return field

## Testing
- `pnpm test` *(fails: TypeError limit is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688961440bf48325b4fdb62e0895385c