### PR TITLE
Replace error strings with createApiError

### DIFF
--- a/src/pages/api/__tests__/chat.test.ts
+++ b/src/pages/api/__tests__/chat.test.ts
@@ -270,7 +270,7 @@ describe('/api/chat (unified endpoint)', () => {
 
       expect(res._getStatusCode()).toBe(405)
       const data = JSON.parse(res._getData())
-      expect(data.error).toBe('Method not allowed')
+      expect(data.error).toBe('HTTP method not allowed for this endpoint')
       expect(data.code).toBe('METHOD_NOT_ALLOWED')
     })
 

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -1,9 +1,10 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { createClient } from '@supabase/supabase-js'
+import { createApiError, ERROR_CODES } from '@/lib/constants/errors'
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
-    return res.status(405).json({ error: 'Method not allowed' })
+    return createApiError(res, ERROR_CODES.METHOD_NOT_ALLOWED)
   }
 
   try {

--- a/src/pages/api/storage/setup.ts
+++ b/src/pages/api/storage/setup.ts
@@ -1,10 +1,11 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import { createClient } from '@supabase/supabase-js'
+import { createApiError, ERROR_CODES } from '@/lib/constants/errors'
 
 // This endpoint should only be called once to set up storage buckets
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
-    return res.status(405).json({ error: 'Method not allowed' })
+    return createApiError(res, ERROR_CODES.METHOD_NOT_ALLOWED)
   }
 
   // Use service role key for admin operations
@@ -66,9 +67,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     })
   } catch (error) {
     console.error('Error setting up storage:', error)
-    return res.status(500).json({ 
-      error: 'Failed to set up storage',
-      details: error instanceof Error ? error.message : 'Unknown error'
-    })
+    return createApiError(
+      res,
+      ERROR_CODES.STORAGE_ERROR,
+      error instanceof Error ? error.message : 'Unknown error'
+    )
   }
 }


### PR DESCRIPTION
## Summary
- swap hardcoded error responses for standardized `createApiError`
- import `ERROR_CODES` in API routes
- adjust unit test expectation

## Testing
- `pnpm install`
- `pnpm test` *(fails: jest not fully configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_688961458be083259866a794c0bfa977