### PR TITLE
fix/vercel-build-lints

### DIFF
--- a/src/lib/agents/pdf-parser/PDFParserAgent.ts
+++ b/src/lib/agents/pdf-parser/PDFParserAgent.ts
@@ -25,7 +25,7 @@ function toPlainUint8Array(d: ArrayBuffer | Uint8Array | Buffer): Uint8Array {
   if (B && B.isBuffer && B.isBuffer(d)) return new Uint8Array((d as any).buffer, (d as any).byteOffset, d.byteLength);
   if (d instanceof ArrayBuffer) return new Uint8Array(d);
   // Last resort copy
-  // @ts-expect-error
+  // @ts-expect-error - allow final fallback for array-like input that TS can't type
   return Uint8Array.from(d);
 }
 
@@ -68,7 +68,7 @@ export class PDFParserAgent implements IPDFParserAgent {
         pdfjsLib.GlobalWorkerOptions.workerSrc = 'pdfjs-dist/legacy/build/pdf.worker.js';
         console.log('[OM-AI] Loaded pdfjs-dist legacy build (worker configured)');
       } catch {
-        // @ts-expect-error
+        // @ts-expect-error - pdfjs legacy build types don't match runtime default export
         const mod = await import('pdfjs-dist/build/pdf.js');
         pdfjsLib = (mod as any).default ?? mod;
         pdfjsLib.GlobalWorkerOptions.workerSrc = 'pdfjs-dist/build/pdf.worker.js';
@@ -128,7 +128,7 @@ export class PDFParserAgent implements IPDFParserAgent {
       // Check if we got any text at all
       if (!hasAnyText) {
         const err = new Error('No extractable text in PDF (image-only).');
-        // @ts-ignore
+        // @ts-expect-error - intentional runtime mismatch; see pdfjs import note
         err.code = 'NO_PDF_TEXT';
         throw err;
       }
@@ -148,7 +148,7 @@ export class PDFParserAgent implements IPDFParserAgent {
 
       if (chunks.length === 0) {
         const err = new Error('Document processing produced no chunks.');
-        // @ts-ignore  
+        // @ts-expect-error - intentional runtime mismatch; see pdfjs import note
         err.code = 'NO_CHUNKS';
         throw err;
       }
@@ -457,7 +457,7 @@ export class PDFParserAgent implements IPDFParserAgent {
       try {
         pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.js');
       } catch {
-        // @ts-expect-error
+        // @ts-expect-error - pdfjs legacy build types don't match runtime default export
         const mod = await import('pdfjs-dist/build/pdf.js');
         pdfjsLib = (mod as any).default ?? mod;
       }

--- a/src/pages/api/process-document.ts
+++ b/src/pages/api/process-document.ts
@@ -130,11 +130,20 @@ async function processDocumentHandler(req: AuthenticatedRequest, res: NextApiRes
       hasError: !!processingResult.error
     })
 
+    const documentId = processingResult.document?.id
+    if (!documentId) {
+      return res.status(500).json({
+        success: false,
+        code: 'NO_DOCUMENT',
+        message: 'Document missing after processing'
+      })
+    }
+
     // Strict validation - verify actual chunk count
     const { count } = await supabaseAdmin
       .from('document_chunks')
       .select('id', { count: 'exact', head: true })
-      .eq('document_id', processingResult.document?.id!)
+      .eq('document_id', documentId)
     
     console.log('[OM-AI] ingest done', { 
       documentId: processingResult.document?.id, 


### PR DESCRIPTION
## Summary
- add explicit reasons for all `@ts-expect-error` uses in `PDFParserAgent`
- replace `@ts-ignore` with `@ts-expect-error` in `PDFParserAgent`
- guard `process-document` chunk validation against missing document ID

## Testing
- `NEXT_FONT_GOOGLE_FETCH_DISABLE=1 pnpm build` *(fails: Failed to fetch `Fira Code`, `Inter`, `Noto Sans` from Google Fonts)*


------
https://chatgpt.com/codex/tasks/task_e_689a734d77c8832584000af8cfcf0e89