### PR TITLE
fix: ensure document ids in structured logs

### DIFF
--- a/src/pages/api/process-pdf-fast.ts
+++ b/src/pages/api/process-pdf-fast.ts
@@ -231,7 +231,7 @@ async function processPdfFastHandler(req: AuthenticatedRequest, res: NextApiResp
             )
             
             structuredLog('info', 'Deal points extracted and cached (async)', {
-              documentId,
+              documentId: documentId || 'none',
               userId,
               contentHash,
               bulletsCount: dealPoints.bullets.length,
@@ -241,7 +241,7 @@ async function processPdfFastHandler(req: AuthenticatedRequest, res: NextApiResp
             })
           } else {
             structuredLog('info', 'Deal points extraction returned null (async)', {
-              documentId,
+              documentId: documentId || 'none',
               userId,
               contentHash,
               source: 'async_extraction',
@@ -250,7 +250,7 @@ async function processPdfFastHandler(req: AuthenticatedRequest, res: NextApiResp
           }
         } catch (extractionError) {
           structuredLog('error', 'Async deal points extraction failed', {
-            documentId,
+            documentId: documentId || 'none',
             userId,
             contentHash,
             error: extractionError instanceof Error ? extractionError.message : 'Unknown error',


### PR DESCRIPTION
## Summary
- ensure fallback text endpoint always supplies a documentId in structured logs
- guard async deal-points extraction logging with default documentId

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` *(fails: Objects are not valid as a React child; OpenAI client error; Method Not Allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68a403b80bf0832599cc5e29ba692624