### PR TITLE
fix: sanitize fallback tool usage

### DIFF
--- a/src/__tests__/api/fallback-text-tools.test.ts
+++ b/src/__tests__/api/fallback-text-tools.test.ts
@@ -1,0 +1,87 @@
+import { createMocks } from 'node-mocks-http'
+import handler from '../../pages/api/chat/fallback-text'
+import { withAuth } from '@/lib/auth-middleware'
+import { createChatCompletion } from '@/lib/services/openai'
+
+// Mock auth middleware and rate limiter
+jest.mock('@/lib/auth-middleware', () => ({
+  withAuth: jest.fn((h: any) => (req: any, res: any) => {
+    req.user = { id: 'test-user-id' }
+    return h(req, res)
+  }),
+  withRateLimit: jest.fn(() => (h: any) => h),
+  apiError: (res: any, status: number, message: string, code?: string) => {
+    res.status(status).json({ error: message, code })
+  }
+}))
+
+// Mock Supabase admin client used in handler
+jest.mock('@/lib/supabaseAdmin', () => ({
+  getSupabaseAdmin: () => ({
+    from: () => ({
+      insert: () => Promise.resolve({ data: { id: 'msg-id' }, error: null })
+    })
+  })
+}))
+
+// Mock KV store
+jest.mock('@/lib/kv-store', () => ({
+  getItem: jest.fn(() => Promise.resolve(null)),
+  setItem: jest.fn(() => Promise.resolve())
+}))
+
+// Mock RAG utilities
+jest.mock('@/lib/rag/retriever', () => ({
+  retrieveTopK: jest.fn(() => Promise.resolve([]))
+}))
+
+jest.mock('@/lib/rag/augment', () => ({
+  augmentMessagesWithContext: jest.fn((_c: any, m: any) => ({ chat: m, responses: m }))
+}))
+
+// Mock logging
+jest.mock('@/lib/log', () => ({
+  structuredLog: jest.fn(),
+  generateRequestId: jest.fn(() => 'test-request-id')
+}))
+
+// Mock OpenAI service
+jest.mock('@/lib/services/openai', () => ({
+  createChatCompletion: jest.fn(() => Promise.resolve({
+    content: 'Fallback response text',
+    model: 'gpt-4o',
+    usage: { total_tokens: 10, prompt_tokens: 5, completion_tokens: 5 }
+  }))
+}))
+
+const createChatCompletionMock = createChatCompletion as unknown as jest.Mock
+
+describe('fallback-text endpoint tool sanitization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(withAuth as jest.Mock).mockImplementation((h: any) => (req: any, res: any) => {
+      req.user = { id: 'test-user-id' }
+      return h(req, res)
+    })
+  })
+
+  it('removes tool_choice when no tools are provided', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hello' }],
+        tool_choice: 'auto'
+      }
+    })
+
+    await handler(req, res)
+
+    expect(res._getStatusCode()).toBe(200)
+    const payload = createChatCompletionMock.mock.calls[0][0]
+    expect(payload.tool_choice).toBeUndefined()
+    expect(payload.tools).toBeUndefined()
+    const data = JSON.parse(res._getData())
+    expect(data.message).toBe('Fallback response text')
+  })
+})


### PR DESCRIPTION
## Summary
- sanitize tool-related fields in `/api/chat/fallback-text` to prevent OpenAI 400 errors
- return a default message when fallback content is empty
- add regression test verifying tool sanitization

## Testing
- `pnpm test` *(fails: storage verify, process-pdf-memory, ChatHistory, etc.)*
- `pnpm test src/__tests__/api/fallback-text-tools.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a43354a89c8325b5eb408e2a4332fe