### PR TITLE
Sanitize OpenAI payloads and add fallback safety test

### DIFF
--- a/src/lib/services/openai/index.ts
+++ b/src/lib/services/openai/index.ts
@@ -1,6 +1,29 @@
 import OpenAI from 'openai'
 import { isResponsesModel } from './modelUtils'
 
+/**
+ * Sanitizes OpenAI payloads to prevent tool_choice without tools errors
+ * Removes undefined values that cause SDK issues
+ */
+function sanitizeOpenAIPayload(payload: any): any {
+  const cleaned = { ...payload }
+
+  // Remove tool_choice if no tools are present
+  if (!cleaned.tools || (Array.isArray(cleaned.tools) && cleaned.tools.length === 0)) {
+    delete cleaned.tool_choice
+    delete cleaned.tools
+  }
+
+  // Remove undefined/null values that cause SDK errors
+  Object.keys(cleaned).forEach(key => {
+    if (cleaned[key] === undefined || cleaned[key] === null) {
+      delete cleaned[key]
+    }
+  })
+
+  return cleaned
+}
+
 // Module-scope client reuse for better performance
 const client = new OpenAI({ 
   apiKey: process.env.OPENAI_API_KEY!,
@@ -43,8 +66,10 @@ export async function createChatCompletion(payload: RequestPayload, options?: { 
   while (true) {
     try {
       if (isResponses) {
-        const responsesParams: any = (({model,input,max_output_tokens,tool_choice,response_format,temperature,stream}) => 
-          ({model,input,max_output_tokens,tool_choice,response_format,temperature,stream}))(payload)
+        const responsesParams: any = sanitizeOpenAIPayload(
+          (({model,input,max_output_tokens,tool_choice,response_format,temperature,stream}) =>
+            ({model,input,max_output_tokens,tool_choice,response_format,temperature,stream}))(payload)
+        )
         // Override with computed values
         responsesParams.model = model
         responsesParams.max_output_tokens = limit
@@ -59,9 +84,11 @@ export async function createChatCompletion(payload: RequestPayload, options?: { 
         const content = resp.output_text ?? resp.content?.[0]?.text ?? ''
         return { content: String(content).trim(), model, usage: resp.usage }
       } else {
-        const chatParams: any = (({model,messages,max_tokens,tool_choice,response_format,temperature,stream}) => 
-          ({model,messages,max_tokens,tool_choice,response_format,temperature,stream}))(payload)
-        // Override with computed values  
+        const chatParams: any = sanitizeOpenAIPayload(
+          (({model,messages,max_tokens,tool_choice,response_format,temperature,stream}) =>
+            ({model,messages,max_tokens,tool_choice,response_format,temperature,stream}))(payload)
+        )
+        // Override with computed values
         chatParams.model = model
         chatParams.messages = payload.messages || []
         chatParams.max_tokens = limit

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -50,12 +50,17 @@ function AppContent({ Component, pageProps }: { Component: any; pageProps: any }
 }
 
 export default function App({ Component, pageProps }: AppProps) {
-  // Register service worker
+  // Register/unregister service worker based on environment
   useEffect(() => {
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/service-worker.js')
-        .then(registration => console.log('Service Worker registered:', registration.scope))
-        .catch(error => console.error('Service Worker registration failed:', error));
+    if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
+      if (process.env.NODE_ENV === 'production') {
+        navigator.serviceWorker.register('/service-worker.js').catch(() => {})
+      } else {
+        // Unregister any SW in development
+        navigator.serviceWorker.getRegistrations().then(regs => {
+          regs.forEach(reg => reg.unregister())
+        })
+      }
     }
   }, []);
 

--- a/src/tests/api/fallback-safety.test.ts
+++ b/src/tests/api/fallback-safety.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment node
+ */
+import { createMocks } from 'node-mocks-http'
+import handler from '@/pages/api/chat/fallback-text'
+import { createChatCompletion } from '@/lib/services/openai'
+
+jest.mock('@/lib/services/openai', () => ({
+  createChatCompletion: jest.fn(async () => ({
+    content: 'fallback response',
+    model: 'gpt-mock',
+    usage: {}
+  }))
+}))
+
+describe('Fallback safety', () => {
+  it('handles tool_choice without tools gracefully', async () => {
+    process.env.ALLOW_DEV_NOAUTH = 'true'
+
+    const payload = {
+      messages: [{ role: 'user', content: 'test' }],
+      tool_choice: 'auto'
+    }
+    jest.useFakeTimers()
+
+    const { req, res } = createMocks({
+      method: 'POST',
+      url: '/api/chat/fallback-text',
+      body: payload
+    })
+
+    await handler(req as any, res as any)
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+
+    expect(res.statusCode).toBe(200)
+    const data = JSON.parse(res._getData())
+    expect(data.message).toBeDefined()
+    expect(data.message.length).toBeGreaterThan(0)
+
+    const callPayload = (createChatCompletion as jest.Mock).mock.calls[0][0]
+    expect(callPayload.tool_choice).toBe('none')
+    expect(callPayload.tools).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- add `sanitizeOpenAIPayload` helper to strip invalid tool calls and undefined fields
- clean up service worker registration to avoid dev console errors
- add integration test ensuring tool_choice without tools is handled gracefully

## Testing
- `pnpm test --testMatch='<rootDir>/src/tests/api/fallback-safety.test.ts'`
- `pnpm test` *(fails: API and component tests require additional setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a4338a9ac08325bff72ac2e4657da2