### PR TITLE
fix: respect response format types

### DIFF
--- a/src/hooks/useChatPersistent.ts
+++ b/src/hooks/useChatPersistent.ts
@@ -563,8 +563,7 @@ export function useChatPersistent(selectedDocumentId?: string | null) {
             body: JSON.stringify({
               ...cleanPayload,
               stream: false,
-              tool_choice: 'none',
-              response_format: { type: 'text' }
+              tool_choice: 'none'
             })
           })
           

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -156,9 +156,10 @@ async function runTextFallback(
         max_tokens: Math.min(originalPayload.max_tokens || 600, 600) 
       })
   
-  // Force text output and disable tools
-  fallbackPayload.tool_choice = 'none'
-  fallbackPayload.response_format = { type: 'text' }
+  // Force text output and disable tools if present
+  if (fallbackPayload.tools && Array.isArray(fallbackPayload.tools) && fallbackPayload.tools.length > 0) {
+    fallbackPayload.tool_choice = 'none'
+  }
   fallbackPayload.stream = false
   
   // Preserve temperature from original (if any)
@@ -820,7 +821,6 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse) {
                   })
                 : buildChatCompletion({ model, messages: stageBMessages, max_tokens: Math.min(max_output_tokens || 400, 400) })
               
-              stageBPayload.response_format = { type: 'text' }
               stageBPayload.stream = false
 
               const stageBStart = Date.now()
@@ -1019,6 +1019,11 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse) {
     const ai = await createChatCompletion(payload, { signal })
     const firstTokenTime = Date.now() - callStartTime
     
+    // Guard against null/undefined AI response properties
+    if (!ai || typeof ai !== 'object') {
+      throw new Error('Invalid AI response: received null or non-object response')
+    }
+    
     // Performance budget monitoring (tightened thresholds)
     if (firstTokenTime > 1500) {
       structuredLog('warn', 'PERF_BUDGET_WARNING', {
@@ -1045,8 +1050,8 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse) {
     }
     
     // Check for tool-only responses (empty text content)
-    const hadText = !!(ai.content && ai.content.trim().length > 0)
-    const hadToolCalls = !!((ai as any).tool_calls && (ai as any).tool_calls.length > 0)
+    const hadText = !!(ai?.content && ai.content.trim().length > 0)
+    const hadToolCalls = !!((ai as any)?.tool_calls && (ai as any).tool_calls.length > 0)
     
     // Handle empty-text fallback for tool-only responses
     if (!hadText && hadToolCalls) {
@@ -1069,16 +1074,17 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse) {
           })
         : buildChatCompletion({ model, messages, max_tokens: Math.min(max_output_tokens || 600, 600) })
       
-      // Force text output and disable tools
-      fallbackPayload.tool_choice = 'none'
-      fallbackPayload.response_format = { type: 'text' }
+      // Force text output and disable tools if present
+      if (fallbackPayload.tools && Array.isArray(fallbackPayload.tools) && fallbackPayload.tools.length > 0) {
+        fallbackPayload.tool_choice = 'none'
+      }
       fallbackPayload.stream = false
 
       try {
         fixResponseFormat(fallbackPayload)
         const fallbackAi = await createChatCompletion(fallbackPayload, { signal })
         
-        if (fallbackAi.content && fallbackAi.content.trim().length > 0) {
+        if (fallbackAi?.content && fallbackAi.content.trim().length > 0) {
           structuredLog('info', 'Fallback text generated successfully', {
             correlationId,
             documentId: requestBody.metadata?.documentId,
@@ -1088,7 +1094,7 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse) {
           })
           
           // Use fallback content
-          ai.content = fallbackAi.content
+          ai.content = fallbackAi.content || ''
           ;(ai as any).finish_reason = 'fallback_text'
         }
       } catch (fallbackError) {
@@ -1104,18 +1110,18 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse) {
     }
 
     // Set X-Text-Bytes header for fallback gating
-    const responseBytes = new TextEncoder().encode(ai.content || '').length
+    const responseBytes = new TextEncoder().encode(ai?.content || '').length
     res.setHeader('X-Text-Bytes', responseBytes.toString())
     
     // Check for empty content after completion - route to fallback instead of 502
-    const hasToolCalls = !!((ai as any).tool_calls && (ai as any).tool_calls.length > 0)
-    if ((!ai.content || ai.content.trim().length === 0) && !hasToolCalls && !signal.aborted) {
+    const hasToolCalls = !!((ai as any)?.tool_calls && (ai as any).tool_calls.length > 0)
+    if ((!ai?.content || ai.content.trim().length === 0) && !hasToolCalls && !signal.aborted) {
       structuredLog('warn', 'Empty content detected - routing to fallback', {
         correlationId,
         documentId: requestBody.metadata?.documentId,
         userId: req.user?.id || 'anonymous',
-        model: ai.model,
-        finish_reason: (ai as any).finish_reason,
+        model: ai?.model || 'unknown',
+        finish_reason: (ai as any)?.finish_reason || 'unknown',
         hasToolCalls,
         request_id: requestId
       })
@@ -1135,9 +1141,9 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse) {
         failure_cause = 'empty_content'
         
         // Use fallback content and continue with response
-        ai.content = fallbackResult.content
-        ai.model = fallbackResult.model
-        ai.usage = fallbackResult.usage
+        ai.content = fallbackResult.content || ''
+        ai.model = fallbackResult.model || model
+        ai.usage = fallbackResult.usage || {}
         ;(ai as any).fallback_reason = 'empty_content'
       } catch (fallbackError) {
         clearTimeout(fallbackTimeout)
@@ -1153,9 +1159,9 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse) {
     
     // Send response first
     const response = res.status(200).json({ 
-      message: ai.content,
-      model: ai.model,
-      usage: ai.usage,
+      message: ai?.content || '',
+      model: ai?.model || model,
+      usage: ai?.usage || {},
       correlationId,
       request_id: requestId
     })
@@ -1168,18 +1174,18 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse) {
           await supabase.from('messages').insert({
             chat_session_id: sessionId,
             role: 'assistant',
-            content: ai.content,
+            content: ai?.content || '',
             metadata: { 
               requestId, 
               correlationId,
-              usage: ai.usage, 
-              model: ai.model,
+              usage: ai?.usage || {}, 
+              model: ai?.model || model,
               apiFamily,
               path: normalizedPath,
-              finish_reason: (ai as any).finish_reason || 'unknown',
-              hadToolCalls: !!((ai as any).tool_calls && (ai as any).tool_calls.length > 0),
-              hadText: !!(ai.content && ai.content.trim().length > 0),
-              fallback_reason: (ai as any).fallback_reason
+              finish_reason: (ai as any)?.finish_reason || 'unknown',
+              hadToolCalls: !!((ai as any)?.tool_calls && (ai as any).tool_calls.length > 0),
+              hadText: !!(ai?.content && ai.content.trim().length > 0),
+              fallback_reason: (ai as any)?.fallback_reason
             }
           })
         } catch (persistErr) {
@@ -1187,6 +1193,17 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse) {
         }
       })
     }
+    
+    // Log successful completion
+    structuredLog('info', 'Chat request completed', {
+      documentId: requestBody?.metadata?.documentId,
+      userId,
+      outcome,
+      failure_cause,
+      latency_ms: Date.now() - startTime,
+      correlationId,
+      request_id: requestId
+    })
     
     return response
     
@@ -1232,6 +1249,17 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse) {
       outcome = 'fallback'  
       failure_cause = 'error'
     }
+    
+    // Log failure before returning error response
+    structuredLog('error', 'Chat request failed', {
+      documentId: requestBody?.metadata?.documentId,
+      userId,
+      outcome,
+      failure_cause,
+      latency_ms: Date.now() - startTime,
+      correlationId,
+      request_id: requestId
+    })
 
     return res.status(statusCode).json({ 
       code: errorType,
@@ -1241,19 +1269,8 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse) {
       request_id: error?.request_id || requestId
     })
   } finally {
-    // Clean up timeout and emit terminal log
+    // Clean up timeout
     clearTimeout(primaryTimeout)
-    
-    // Single terminal log per request
-    structuredLog('info', 'Chat request completed', {
-      documentId: requestBody?.metadata?.documentId,
-      userId,
-      outcome,
-      failure_cause,
-      latency_ms: Date.now() - startTime,
-      correlationId,
-      request_id: requestId
-    })
   }
 }
 


### PR DESCRIPTION
## Summary
- only strip `response_format` when explicitly set to text
- forward `text` field to Responses API
- sanitize chat payloads before calling OpenAI

## Testing
- `pnpm lint --file src/pages/api/chat.ts --file src/lib/services/openai/index.ts`
- `pnpm test` *(fails: ChatHistory test suite and process-pdf-memory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bda585c8832589c7303b95ef7d6e