### PR TITLE
Fix requestId duplication and GPT-5 chat routing

### DIFF
--- a/src/pages/api/chat/fallback-text.ts
+++ b/src/pages/api/chat/fallback-text.ts
@@ -78,10 +78,10 @@ async function fallbackTextHandler(req: AuthenticatedRequest, res: NextApiRespon
   } catch (idempotencyError) {
     structuredLog('warn', 'Failed to check/set idempotency', {
       documentId: rawDocumentId,
-      requestId: clientRequestId,
+      clientRequestId,
       userId,
       error: idempotencyError instanceof Error ? idempotencyError.message : 'Unknown error',
-      requestId: requestId
+      requestId
     })
     // Continue processing if KV fails - better to allow than block legitimate requests
   }


### PR DESCRIPTION
## Summary
- prevent duplicate requestId log fields in fallback handler
- route GPT-5/Responses requests directly to chat handler even when conversational mode is enabled

## Testing
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` *(fails: Storage verification missing env vars, process-pdf-memory, OpenAI service tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a6baa8987c8325ba3065339dd0fb48