### PR TITLE
Ensure markdown bullet lists in chat API

### DIFF
--- a/src/lib/chat/handlers/completions.ts
+++ b/src/lib/chat/handlers/completions.ts
@@ -15,28 +15,28 @@ const STRUCTURED_OUTPUT_SYSTEM_MESSAGE = {
 When analyzing documents, structure your response as follows:
 
 **📊 Key Metrics**
-• Property: [Name and address]
-• Price: [Asking price, price/unit, price/SF]
-• Size: [Units/SF, year built]
-• Returns: [Cap rate, NOI, GRM]
+- Property: [Name and address]
+- Price: [Asking price, price/unit, price/SF]
+- Size: [Units/SF, year built]
+- Returns: [Cap rate, NOI, GRM]
 
 **💰 Financial Performance**
-• Current NOI: [Amount and key drivers]
-• Income: [Gross income, effective income, occupancy]
-• Expenses: [Operating expenses, expense ratio]
-• Upside: [Pro forma NOI, value-add opportunities]
+- Current NOI: [Amount and key drivers]
+- Income: [Gross income, effective income, occupancy]
+- Expenses: [Operating expenses, expense ratio]
+- Upside: [Pro forma NOI, value-add opportunities]
 
 **🏢 Property Overview**
-• Type & Condition: [Property type, age, recent renovations]
-• Unit Mix: [Brief breakdown of unit types and rents]
-• Occupancy: [Current and historical]
-• Market Position: [Compared to submarket]
+- Type & Condition: [Property type, age, recent renovations]
+- Unit Mix: [Brief breakdown of unit types and rents]
+- Occupancy: [Current and historical]
+- Market Position: [Compared to submarket]
 
 **📍 Location Insights**
-• Submarket: [Area name and characteristics]
-• Access: [Transit, highways, walkability]
-• Anchors: [Major employers, retail, amenities]
-• Demographics: [Key population and income metrics]
+- Submarket: [Area name and characteristics]
+- Access: [Transit, highways, walkability]
+- Anchors: [Major employers, retail, amenities]
+- Demographics: [Key population and income metrics]
 
 **⚡ Investment Highlights**
 [Top 3-5 most compelling investment points as bullet points]

--- a/src/lib/chat/handlers/responses.ts
+++ b/src/lib/chat/handlers/responses.ts
@@ -15,28 +15,28 @@ const STRUCTURED_OUTPUT_SYSTEM_MESSAGE = {
 When analyzing documents, structure your response as follows:
 
 **📊 Key Metrics**
-• Property: [Name and address]
-• Price: [Asking price, price/unit, price/SF]
-• Size: [Units/SF, year built]
-• Returns: [Cap rate, NOI, GRM]
+- Property: [Name and address]
+- Price: [Asking price, price/unit, price/SF]
+- Size: [Units/SF, year built]
+- Returns: [Cap rate, NOI, GRM]
 
 **💰 Financial Performance**
-• Current NOI: [Amount and key drivers]
-• Income: [Gross income, effective income, occupancy]
-• Expenses: [Operating expenses, expense ratio]
-• Upside: [Pro forma NOI, value-add opportunities]
+- Current NOI: [Amount and key drivers]
+- Income: [Gross income, effective income, occupancy]
+- Expenses: [Operating expenses, expense ratio]
+- Upside: [Pro forma NOI, value-add opportunities]
 
 **🏢 Property Overview**
-• Type & Condition: [Property type, age, recent renovations]
-• Unit Mix: [Brief breakdown of unit types and rents]
-• Occupancy: [Current and historical]
-• Market Position: [Compared to submarket]
+- Type & Condition: [Property type, age, recent renovations]
+- Unit Mix: [Brief breakdown of unit types and rents]
+- Occupancy: [Current and historical]
+- Market Position: [Compared to submarket]
 
 **📍 Location Insights**
-• Submarket: [Area name and characteristics]
-• Access: [Transit, highways, walkability]
-• Anchors: [Major employers, retail, amenities]
-• Demographics: [Key population and income metrics]
+- Submarket: [Area name and characteristics]
+- Access: [Transit, highways, walkability]
+- Anchors: [Major employers, retail, amenities]
+- Demographics: [Key population and income metrics]
 
 **⚡ Investment Highlights**
 [Top 3-5 most compelling investment points as bullet points]

--- a/src/lib/prompts/om-analyst-development.ts
+++ b/src/lib/prompts/om-analyst-development.ts
@@ -87,23 +87,23 @@ Use ONLY information explicitly stated in the provided document chunks.`;
 export const OM_ANALYST_DEVELOPMENT_SUMMARY_V1 = `You are analyzing a DEVELOPMENT deal offering memorandum. Provide a concise summary:
 
 **Development Snapshot**
-• Project: [Name, location, type]
-• Total Cost: [TDC amount]
-• Capital Stack: [Equity %, Debt %]
-• Delivery: [Expected completion]
+- Project: [Name, location, type]
+- Total Cost: [TDC amount]
+- Capital Stack: [Equity %, Debt %]
+- Delivery: [Expected completion]
 
 **Key Development Metrics**
-• Yield on Cost: [%]
-• Stabilized NOI: [$]
-• Exit Cap: [%]
-• Project IRR/Multiple: [%, x]
-• LP IRR/Multiple: [%, x]
+- Yield on Cost: [%]
+- Stabilized NOI: [$]
+- Exit Cap: [%]
+- Project IRR/Multiple: [%, x]
+- LP IRR/Multiple: [%, x]
 
 **Development Program**
-• Units: [Count and mix]
-• Commercial: [Retail/office SF if any]
-• Parking: [Spaces and ratio]
-• Site: [Acres]
+- Units: [Count and mix]
+- Commercial: [Retail/office SF if any]
+- Parking: [Spaces and ratio]
+- Site: [Acres]
 
 **Top 3 Development Risks**
 1. [Construction/entitlement risk]

--- a/src/lib/prompts/om-analyst-natural.ts
+++ b/src/lib/prompts/om-analyst-natural.ts
@@ -36,28 +36,28 @@ export const OM_ANALYST_NATURAL_PROMPT_V1 = `You are OM Intel, an elite commerci
 When analyzing documents, structure your response as follows:
 
 **📊 Key Metrics**
-• Property: [Name and address]
-• Price: [Asking price, price/unit, price/SF]
-• Size: [Units/SF, year built]
-• Returns: [Cap rate, NOI, GRM]
+- Property: [Name and address]
+- Price: [Asking price, price/unit, price/SF]
+- Size: [Units/SF, year built]
+- Returns: [Cap rate, NOI, GRM]
 
 **💰 Financial Performance**
-• Current NOI: [Amount and key drivers]
-• Income: [Gross income, effective income, occupancy]
-• Expenses: [Operating expenses, expense ratio]
-• Upside: [Pro forma NOI, value-add opportunities]
+- Current NOI: [Amount and key drivers]
+- Income: [Gross income, effective income, occupancy]
+- Expenses: [Operating expenses, expense ratio]
+- Upside: [Pro forma NOI, value-add opportunities]
 
 **🏢 Property Overview**
-• Type & Condition: [Property type, age, recent renovations]
-• Unit Mix: [Brief breakdown of unit types and rents]
-• Occupancy: [Current and historical]
-• Market Position: [Compared to submarket]
+- Type & Condition: [Property type, age, recent renovations]
+- Unit Mix: [Brief breakdown of unit types and rents]
+- Occupancy: [Current and historical]
+- Market Position: [Compared to submarket]
 
 **📍 Location Insights**
-• Submarket: [Area name and characteristics]
-• Access: [Transit, highways, walkability]
-• Anchors: [Major employers, retail, amenities]
-• Demographics: [Key population and income metrics]
+- Submarket: [Area name and characteristics]
+- Access: [Transit, highways, walkability]
+- Anchors: [Major employers, retail, amenities]
+- Demographics: [Key population and income metrics]
 
 **⚡ Investment Highlights**
 [Top 3-5 most compelling investment points as bullet points]
@@ -80,10 +80,10 @@ export const OM_ANALYST_SUMMARY_PROMPT_V1 = `You are OM Intel, an elite commerci
 Structure your response as:
 
 **Deal Snapshot**
-• Property: [Name, address, type]
-• Price: [Total, per unit, per SF]
-• Size: [Units/SF]
-• Returns: [Cap rate, NOI]
+- Property: [Name, address, type]
+- Price: [Total, per unit, per SF]
+- Size: [Units/SF]
+- Returns: [Cap rate, NOI]
 
 **Top 3 Investment Highlights**
 1. [Most compelling point]
@@ -108,10 +108,10 @@ Be extremely concise. Focus only on what matters most.`;
 export const OM_ANALYST_SPECIFIC_PROMPT_V1 = `You are OM Intel, an elite commercial real estate analyst. Answer the specific question about the document directly and concisely.
 
 Guidelines:
-• Give the exact data requested first
-• Provide brief context if helpful
-• Note if the information is not available
-• Add relevant related metrics only if they directly support the answer
+- Give the exact data requested first
+- Provide brief context if helpful
+- Note if the information is not available
+- Add relevant related metrics only if they directly support the answer
 
 Keep your response focused and to the point. No need for extensive formatting unless it helps clarity.`;
 

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -564,7 +564,7 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse): Pro
               const bullet = cachedDealPoints.bullets[i]
               const citation = cachedDealPoints.citations?.[i]
               const pageRef = citation?.page ? ` (Page ${citation.page})` : ''
-              fastPathResponse += `• ${bullet}${pageRef}\n`
+              fastPathResponse += `- ${bullet}${pageRef}\n`
             }
             
             // Add metadata footer
@@ -903,7 +903,7 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse): Pro
                   const bullet = parsed.bullets[i]
                   const citation = parsed.citations?.[i]
                   const pageRef = citation?.page ? ` (Page ${citation.page})` : ''
-                  stageAResponse += `• ${bullet}${pageRef}\n`
+                  stageAResponse += `- ${bullet}${pageRef}\n`
                 }
               }
               


### PR DESCRIPTION
## Summary
- replace Unicode bullets with Markdown hyphens in chat fast-path and Stage A responses
- update system prompt templates and OM analyst prompts to use Markdown list markers

## Testing
- `pnpm test` *(fails: Test Suites: 13 failed, 1 skipped, 11 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68abcdf256dc83258b29bd1be76ab8dd