### PR TITLE
Fix OpenAI routing and empty response handling

### DIFF
--- a/src/lib/services/openai/client-wrapper.ts
+++ b/src/lib/services/openai/client-wrapper.ts
@@ -85,8 +85,7 @@ async function callOpenAI(
     const request: any = {
       model,
       max_output_tokens: options.maxTokens, // Responses API uses max_output_tokens
-      stream: options.stream,
-      ...(options.temperature !== undefined && { temperature: options.temperature })
+      stream: options.stream
     };
     
     // Responses API expects 'input' not 'messages'

--- a/src/lib/services/openai/index.ts
+++ b/src/lib/services/openai/index.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai'
-import { isResponsesModel } from './modelUtils'
+import { validateModel, detectAPIType, getModelConfiguration } from '@/lib/config/validate-models'
 
 /**
  * Fixes response_format for different API types. 
@@ -13,7 +13,7 @@ export function fixResponseFormat(payload: any) {
   }
   
   // Responses API doesn't support response_format parameter
-  if (payload?.model && isResponsesModel(payload.model)) {
+  if (payload?.model && detectAPIType(payload.model) === 'responses') {
     delete payload.response_format
   }
 }
@@ -67,9 +67,7 @@ interface RequestPayload {
 
 // Fast model configuration helper
 export function getFastModel(): string {
-  return process.env.USE_FAST_MODEL === 'true' ? 
-    (process.env.CHAT_MODEL_FAST || 'gpt-4o-mini') : 
-    (process.env.OPENAI_MODEL || 'gpt-4o')
+  return getModelConfiguration().fast
 }
 
 // Safe signal combining helper
@@ -123,39 +121,45 @@ export async function createChatCompletion(
     
     fixResponseFormat(payload)
     const model = payload.model || getFastModel()
-    const isResponses = isResponsesModel(model) || !!payload.input
+    const validation = validateModel(model)
+    if (!validation.valid) {
+      const error = new Error(`Invalid model: ${model}`)
+      ;(error as any).code = 'MODEL_UNAVAILABLE'
+      throw error
+    }
+    const apiFamily = validation.apiType!
     const limit =
-      payload.max_output_tokens ??
-      payload.max_tokens ??
+      payload[validation.paramKey!] ??
       Number(process.env.CHAT_MAX_TOKENS ?? 1500) // Reduced for speed
 
     let attempt = 0
   while (true) {
     try {
-      if (isResponses) {
-        let responsesParams: any = (({model,input,text,max_output_tokens,tool_choice,response_format,temperature,stream}) =>
-          ({model,input,text,max_output_tokens,tool_choice,response_format,temperature,stream}))(payload)
-        // Override with computed values
-        responsesParams.model = model
-        // Don't override token params if already provided by getTokenParam
-        if (!responsesParams.max_output_tokens) {
-          // Default fallback only if no token param provided
-          responsesParams.max_output_tokens = limit
+      if (apiFamily === 'responses') {
+        const responsesParams: any = {
+          model,
+          stream: payload.stream,
+          [validation.paramKey!]: limit
         }
-        // Add reasoning parameter for Responses API
+        if (payload.input) {
+          responsesParams.input = payload.input
+        } else if (payload.messages) {
+          responsesParams.input = payload.messages.map(m => ({ role: m.role, content: m.content }))
+        } else if (payload.text) {
+          responsesParams.input = payload.text
+        }
+        if (payload.tool_choice) responsesParams.tool_choice = payload.tool_choice
+        if (payload.response_format) responsesParams.response_format = payload.response_format
         if (!responsesParams.reasoning) {
           responsesParams.reasoning = { effort: "low" }
         }
         // Sanitize the payload
-        responsesParams = sanitizeOpenAIPayload(responsesParams)
-        
-        const resp: any = await client.responses.create(responsesParams, {
-          signal: combinedSignal
-        })
+        const cleanResponses = sanitizeOpenAIPayload(responsesParams)
+
+        const resp: any = await client.responses.create(cleanResponses, { signal: combinedSignal })
         // Parse Responses API format: find message type in output and extract text
         let content = resp.output_text ?? ''
         if (!content && resp.output) {
-          // Find the message output (not reasoning)
           const messageOutput = resp.output.find((item: any) => item.type === 'message')
           if (messageOutput?.content?.[0]?.text) {
             content = messageOutput.content[0].text
@@ -163,21 +167,19 @@ export async function createChatCompletion(
         }
         return { content: String(content).trim(), model, usage: resp.usage }
       } else {
-        let chatParams: any = (({model,messages,max_tokens,tool_choice,response_format,temperature,stream}) => 
-          ({model,messages,max_tokens,tool_choice,response_format,temperature,stream}))(payload)
-        // Override with computed values  
-        chatParams.model = model
-        chatParams.messages = payload.messages || []
-        // Don't override max_tokens if already set by getMaxTokensParam
-        if (!chatParams.max_tokens) {
-          chatParams.max_tokens = limit
+        const chatParams: any = {
+          model,
+          messages: payload.messages || [],
+          stream: payload.stream,
+          [validation.paramKey!]: limit
         }
-        // Sanitize the payload
-        chatParams = sanitizeOpenAIPayload(chatParams)
-        
-        const resp: any = await client.chat.completions.create(chatParams, {
-          signal: combinedSignal
-        })
+        if (payload.tool_choice) chatParams.tool_choice = payload.tool_choice
+        if (payload.response_format) chatParams.response_format = payload.response_format
+        if (payload.temperature !== undefined) chatParams.temperature = payload.temperature
+
+        const cleanChat = sanitizeOpenAIPayload(chatParams)
+
+        const resp: any = await client.chat.completions.create(cleanChat, { signal: combinedSignal })
         const content = String(resp.choices?.[0]?.message?.content ?? '').trim()
         return {
           content,

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -175,8 +175,6 @@ async function runTextFallback(
   }
 }
 
-const SAFE_FALLBACK_MESSAGE = "I couldn't generate a response. Please try rephrasing your question or ensure a document is uploaded."
-
 const MIN_PARTS = parseInt(process.env.MIN_PARTS || '5', 10)
 
 /**
@@ -738,9 +736,10 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse): Pro
     
     if (isDeepAnalysisQuery) {
       try {
-        // Stage A: Fast extraction with gpt-4o-mini in parallel with any remaining retrieval
+        // Stage A: Fast extraction with configured fast model in parallel with any remaining retrieval
+        const fastModel = getModelConfiguration().fast
         const stageAPayload = {
-          model: 'gpt-4o-mini',
+          model: fastModel,
           messages: messages.map(m => ({ role: m.role, content: m.content })),
           response_format: { 
             type: 'json_schema' as const,
@@ -777,7 +776,7 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse): Pro
               }
             }
           },
-          ...getTokenParam('gpt-4o-mini', 350),
+          ...getTokenParam(fastModel, 350),
           temperature: 0.1
         }
         
@@ -884,7 +883,7 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse): Pro
                     completion_tokens: (stageAResult.usage?.completion_tokens || 0) + (stageBResult.usage?.completion_tokens || 0)
                   },
                   cascade: {
-                    stageA: { time: stageATime, model: 'gpt-4o-mini', distinctPages },
+                    stageA: { time: stageATime, model: fastModel, distinctPages },
                     stageB: { time: stageBTime, model: stageBResult.model || model }
                   }
                 }
@@ -921,10 +920,10 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse): Pro
               
               cascadeResult = {
                 content: stageAResponse,
-                model: 'gpt-4o-mini',
+                model: fastModel,
                 usage: stageAResult.usage,
                 cascade: {
-                  stageA: { time: stageATime, model: 'gpt-4o-mini', distinctPages },
+                  stageA: { time: stageATime, model: fastModel, distinctPages },
                   stageBSkipped: 'sufficient_pages_or_low_confidence'
                 }
               }
@@ -1225,20 +1224,21 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse): Pro
     res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate')
     res.setHeader('X-Correlation-ID', correlationId)
     
-    // Ensure we always return non-empty content
-    let finalContent = ai?.content && ai.content.trim().length > 0 ? ai.content : SAFE_FALLBACK_MESSAGE
-    if (finalContent === SAFE_FALLBACK_MESSAGE) {
-      structuredLog('info', 'Applied safe fallback message for empty content', {
-        requestId,
-        userId,
-        reason: 'final_response_empty'
+    // Ensure we have valid content
+    if (!ai?.content || ai.content.trim().length === 0) {
+      structuredLog('error', 'Empty AI response', { requestId, model: ai?.model || model })
+      return res.status(502).json({
+        error: 'empty_text',
+        code: 'EMPTY_RESPONSE',
+        message: 'The AI response was empty',
+        requestId: requestId
       })
-    } else {
-      // Normalize final content for consistent markdown rendering
-      finalContent = normalizeMarkdownBullets(finalContent, requestId).content
     }
-    
-    res.status(200).json({ 
+
+    // Normalize final content for consistent markdown rendering
+    const finalContent = normalizeMarkdownBullets(ai.content, requestId).content
+
+    res.status(200).json({
       message: finalContent,
       model: ai?.model || model,
       usage: ai?.usage || {},
@@ -1276,11 +1276,10 @@ async function chatHandler(req: AuthenticatedRequest, res: NextApiResponse): Pro
     }
     
     // Log successful completion
-    const finalOutcome = finalContent === SAFE_FALLBACK_MESSAGE ? 'empty' : 'success'
     structuredLog('info', 'Chat request completed', {
       documentId: requestBody?.metadata?.documentId,
       userId,
-      outcome: finalOutcome,
+      outcome: 'success',
       parts: status?.parts || 0,
       failure_cause,
       latency_ms: Date.now() - startTime,

--- a/src/pages/api/process-pdf-fast.ts
+++ b/src/pages/api/process-pdf-fast.ts
@@ -650,29 +650,32 @@ async function extractDealPoints(chunks: any[], contentHash: string, requestId?:
     const extractionResult = await createChatCompletion(extractionPayload, {
       requestId: dealPointRequestId
     })
-    
-    if (extractionResult.content) {
-      // Use safe parser with fallback strategies
-      const parsed = parseDealPointsSafe(extractionResult.content)
-      
-      if (parsed.bullets && parsed.bullets.length > 0) {
-        // Success - we have bullets
-        console.log('[extractDealPoints] Deal points extraction completed with', parsed.bullets.length, 'bullets')
-        
-        return {
-          bullets: parsed.bullets.slice(0, 10), // Limit to 10 bullets
-          citations: [], // Citations will be empty for now since we're using strict JSON
-          createdAt: new Date().toISOString(),
-          contentHash,
-          version: 2,
-          extractorVersion: EXTRACTOR_VERSION,
-          source: 'ai'
-        }
-      } else {
-        console.log('[extractDealPoints] No bullets extracted from AI response')
-      }
+
+    if (!extractionResult.content || extractionResult.content.trim() === '') {
+      structuredLog('error', 'Empty AI response', { requestId: dealPointRequestId, model: modelConfig.fast })
+      return null
     }
-    
+
+    // Use safe parser with fallback strategies
+    const parsed = parseDealPointsSafe(extractionResult.content)
+
+    if (parsed.bullets && parsed.bullets.length > 0) {
+      // Success - we have bullets
+      console.log('[extractDealPoints] Deal points extraction completed with', parsed.bullets.length, 'bullets')
+
+      return {
+        bullets: parsed.bullets.slice(0, 10), // Limit to 10 bullets
+        citations: [], // Citations will be empty for now since we're using strict JSON
+        createdAt: new Date().toISOString(),
+        contentHash,
+        version: 2,
+        extractorVersion: EXTRACTOR_VERSION,
+        source: 'ai'
+      }
+    } else {
+      console.log('[extractDealPoints] No bullets extracted from AI response')
+    }
+
     return null
     
   } catch (error) {


### PR DESCRIPTION
## Summary
- use configured fast model in chat cascade instead of hard-coded `gpt-4o-mini`
- validate models and route GPT-5 requests through Responses API with filtered params
- log and return errors when OpenAI responses are empty

## Testing
- `USE_CANVAS=false npx jest src/pages/api/__tests__/chat-markdown-rendering.test.ts --testEnvironment=node`
- `curl -X POST http://localhost:3000/api/chat -H "Content-Type: application/json" -d '{"messages":[{"role":"user","content":"What are the key deal points?"}],"metadata":{"documentId":"mem-01K3FPQ4TKF3G7DEJ3P7SYTBPK"},"stream":false}'` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abe742d258832581b9406bb577a700